### PR TITLE
Fix typo in redisWorker.py

### DIFF
--- a/redisWorker.py
+++ b/redisWorker.py
@@ -279,7 +279,7 @@ class Worker:
     ########### util #############
     def return_most_recent_task(self):
         """
-        if the node is going to OOM, then kill the most recent process and return it to mamager
+        if the node is going to OOM, then kill the most recent process and return it to manager
         """
         try:
             self.lock.acquire()


### PR DESCRIPTION
mamager -> manager on ln # 282.

![image](https://github.com/1a1a11a/distComp/assets/113312245/a19e1a8a-68c7-45ea-8186-370c4271fca4)
